### PR TITLE
chore: Parcelのビルド設定を更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
       "devDependencies": {
         "@dprint/typescript": "^0.95.8",
         "@fullhuman/postcss-purgecss": "^7.0.2",
+        "@parcel/packager-ts": "^2.16.1",
+        "@parcel/transformer-typescript-types": "^2.16.1",
         "@playwright/test": "^1.56.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.10",
@@ -2487,6 +2489,24 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/packager-ts": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.16.1.tgz",
+      "integrity": "sha512-WyHjfo9BVLL3BIuR5EsIrnIeCXnzhKKDFJ/4ZmUc+CZNJMVljFbmdoqsg8YqI8aHxRENeEumbxN3zdnkqfbhyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/plugin": "2.16.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/packager-wasm": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.16.1.tgz",
@@ -3177,6 +3197,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-typescript-types": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.16.1.tgz",
+      "integrity": "sha512-BjDoYd4Gjg3xeOyaPoYlQrBwlHirR32e294qCitXQeTuExQSOYCJgxy4b2gtX/dF4O0jMBLb5ixV/K4sZwLRGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/ts-utils": "2.16.1",
+        "@parcel/utils": "2.16.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "typescript": ">=3.0.0"
+      }
+    },
+    "node_modules/@parcel/ts-utils": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.16.1.tgz",
+      "integrity": "sha512-UuH60I/cGOy/b++Zx8h4qI2V8DXlmMyTYcUPi+x5JHT6L1VZBWohsz6qlP+Iek4BTMMs/g52Q57q++3eLD8Rdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "typescript": ">=3.0.0"
       }
     },
     "node_modules/@parcel/types": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "bin": {
     "padtools_ts": "dist/cli/cli.js"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "LICENSE",
@@ -23,9 +21,9 @@
     "update-cli-golden-files": "node tests/cli/E2E/updateGoldenFile.js",
     "update-spd-golden-files": "node tests/spd/E2E/updateGoldenFile.js",
     "lint": "eslint src/**/*.ts web/**/*.ts",
-    "start:web": "parcel web/index.html web/commands.html --dist-dir temp/",
-    "build:web": "rimraf dist/web && parcel build web/index.html web/commands.html --dist-dir dist/web",
-    "build:web:gh-pages": "rimraf docs/ && parcel build web/index.html web/commands.html --dist-dir docs/ --public-url /padtools_ts/",
+    "start:web": "parcel web/index.html --dist-dir temp/",
+    "build:web": "rimraf dist/web && parcel build web/index.html --dist-dir dist/web",
+    "build:web:gh-pages": "rimraf docs/ && parcel build web/index.html --dist-dir docs/ --public-url /padtools_ts/",
     "convert:web:commands": "ts-node web/utility/convert_commands.ts",
     "convert:web:render_options": "ts-node web/utility/convert_render_options.ts"
   },
@@ -52,6 +50,8 @@
   "devDependencies": {
     "@dprint/typescript": "^0.95.8",
     "@fullhuman/postcss-purgecss": "^7.0.2",
+    "@parcel/packager-ts": "^2.16.1",
+    "@parcel/transformer-typescript-types": "^2.16.1",
     "@playwright/test": "^1.56.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.10",


### PR DESCRIPTION
Parcel v2 の推奨設定に合わせて、ビルド関連の構成を更新します。

- `package.json` から不要となった `main` および `types` フィールドを削除
- TypeScript の型定義を正しく出力するため、`@parcel/packager-ts` と `@parcel/transformer-typescript-types` を `devDependencies` に追加
- Webページのビルドスクリプトを簡素化