### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     name: gitleaks


### PR DESCRIPTION
Potential fix for [https://github.com/steelpipe75/padtools_ts/security/code-scanning/1](https://github.com/steelpipe75/padtools_ts/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/pipeline.yml` so all jobs inherit least-privilege token access by default.

Best single fix without changing functionality:
- Insert at workflow root (after `on:` and before `jobs:`):
  - `permissions:`
  - `contents: read`

Why this is best:
- `actions/checkout@v4` requires `contents: read`.
- None of the shown jobs clearly need write scopes.
- A workflow-level block is minimal, clear, and applies consistently to all jobs unless overridden later.

No imports, methods, or external definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
