### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/tests/cli/E2E/E2E.spec.ts
+++ b/tests/cli/E2E/E2E.spec.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -45,7 +45,7 @@ describe("CLI E2E tests", () => {
             if (option) {
               args.push(option);
             }
-            execFileSync("npx", args);
+            execFileSync("npx", args, { shell: true });
           }).not.toThrow();
 
           const actual = fs.readFileSync(outputPath, "utf-8");
@@ -217,7 +217,7 @@ describe("CLI E2E tests", () => {
       try {
         execSync(command);
         // If execSync does not throw, the test should fail.
-        fail("The command should have failed but it completed successfully.");
+        throw new Error("The command should have failed but it completed successfully.");
       } catch (_error: unknown) {
         if (_error && typeof _error === "object" && "status" in _error) {
           expect(_error.status).toBe(1);

--- a/tests/cli/E2E/E2E.spec.ts
+++ b/tests/cli/E2E/E2E.spec.ts
@@ -41,7 +41,14 @@ describe("CLI E2E tests", () => {
           // The command should execute successfully (exit code 0).
           // execSync will throw an error for non-zero exit codes.
           expect(() => {
-            const args = ["tsx", "src/cli/cli.ts", "-i", inputPath, "-o", outputPath];
+            const args = [
+              "tsx",
+              "src/cli/cli.ts",
+              "-i",
+              inputPath,
+              "-o",
+              outputPath,
+            ];
             if (option) {
               args.push(option);
             }
@@ -217,7 +224,9 @@ describe("CLI E2E tests", () => {
       try {
         execSync(command);
         // If execSync does not throw, the test should fail.
-        throw new Error("The command should have failed but it completed successfully.");
+        throw new Error(
+          "The command should have failed but it completed successfully.",
+        );
       } catch (_error: unknown) {
         if (_error && typeof _error === "object" && "status" in _error) {
           expect(_error.status).toBe(1);

--- a/tests/cli/E2E/E2E.spec.ts
+++ b/tests/cli/E2E/E2E.spec.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -41,9 +41,11 @@ describe("CLI E2E tests", () => {
           // The command should execute successfully (exit code 0).
           // execSync will throw an error for non-zero exit codes.
           expect(() => {
-            execSync(
-              `npx tsx src/cli/cli.ts -i ${inputPath} -o ${outputPath} ${option}`,
-            );
+            const args = ["tsx", "src/cli/cli.ts", "-i", inputPath, "-o", outputPath];
+            if (option) {
+              args.push(option);
+            }
+            execFileSync("npx", args);
           }).not.toThrow();
 
           const actual = fs.readFileSync(outputPath, "utf-8");


### PR DESCRIPTION
Potential fix for [https://github.com/steelpipe75/padtools_ts/security/code-scanning/4](https://github.com/steelpipe75/padtools_ts/security/code-scanning/4)

Use argument-vector execution instead of shell-string execution. In Node, replace `execSync(commandString)` with `execFileSync(file, args)` so `inputPath` and `outputPath` are passed as literal arguments, not shell-parsed text.

In `tests/cli/E2E/E2E.spec.ts`:
- Update the child-process import to include `execFileSync`.
- Replace the `execSync(...)` call at the test body (around lines 44–46) with `execFileSync("npx", [...])`.
- Build args explicitly: `["tsx", "src/cli/cli.ts", "-i", inputPath, "-o", outputPath]`, and append `option` only when non-empty to preserve current behavior.

No functionality change: still runs `npx tsx src/cli/cli.ts ...`, still throws on non-zero exit, still supports optional pretty flag.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
