### PR TITLE
Potential fix for code scanning alert no. 5: Exception text reinterpreted as HTML

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -81,13 +81,19 @@ document.addEventListener("DOMContentLoaded", () => {
       const svgString = renderSvg(ast, options);
       svgOutput.innerHTML = svgString;
     } catch (error) {
+      const errorParagraph = document.createElement("p");
+      errorParagraph.style.color = "red";
+      svgOutput.textContent = "";
+
       if (error instanceof Error) {
-        svgOutput.innerHTML = `<p style="color: red;">Error: ${error.message}</p>`;
+        errorParagraph.textContent = `Error: ${error.message}`;
         console.error("SPD conversion error:", error);
       } else {
-        svgOutput.innerHTML = `<p style="color: red;">An unknown error occurred</p>`;
+        errorParagraph.textContent = "An unknown error occurred";
         console.error("An unknown error occurred:", error);
       }
+
+      svgOutput.appendChild(errorParagraph);
     }
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/steelpipe75/padtools_ts/security/code-scanning/5](https://github.com/steelpipe75/padtools_ts/security/code-scanning/5)

Use safe text rendering for error messages instead of interpolating into `innerHTML`.  
Best fix (without changing functionality): keep `innerHTML` for trusted SVG rendering success path, but in the `catch` block render errors via DOM text APIs (`textContent`) and append a `<p>` element with red styling. This preserves appearance while ensuring `error.message` is not parsed as HTML.

**File to change:** `web/src/main.ts`  
**Region:** `convertAndRender` catch block around current lines 83–89.

Implementation details:
- Replace:
  - `svgOutput.innerHTML = \`<p ...>Error: ${error.message}</p>\`;`
  - `svgOutput.innerHTML = \`<p ...>An unknown error occurred</p>\`;`
- With:
  - clear output (`svgOutput.textContent = ""`)
  - create `<p>` via `document.createElement("p")`
  - set `style.color = "red"`
  - set `textContent` to either `Error: ${error.message}` or fallback message
  - append to `svgOutput`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
