### PR TITLE
Potential fix for code scanning alert no. 6: Unsafe HTML constructed from library input

### DIFF
--- a/src/spd/svg-renderer.ts
+++ b/src/spd/svg-renderer.ts
@@ -882,6 +882,18 @@ function measureTextSvg(
 }
 
 /**
+ * XML/SVGで安全に利用するためのエスケープ
+ */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
  * テキストをSVG形式で描画
  */
 function renderTextSvg(
@@ -896,9 +908,9 @@ function renderTextSvg(
     const dy = index === 0 ? 0 : index * options.fontSize * options.lineHeight;
     svg += `<text `;
     svg += `x="${posX.toFixed(1)}" y="${(posY + options.fontSize).toFixed(1)}" dy="${dy.toFixed(1)}" `;
-    svg += `font-family="${options.fontFamily}" `;
+    svg += `font-family="${escapeXml(options.fontFamily)}" `;
     svg += `font-size="${options.fontSize}" `;
-    svg += `fill="${options.textColor}">${line}</text>`;
+    svg += `fill="${escapeXml(options.textColor)}">${escapeXml(line)}</text>`;
   });
   return svg;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/steelpipe75/padtools_ts/security/code-scanning/6](https://github.com/steelpipe75/padtools_ts/security/code-scanning/6)

To fix this safely without changing functionality, escape all dynamic text/attribute content before embedding into SVG markup. The most targeted fix in the shown code is:

1. Add a local XML escaping helper (for `& < > " '`).
2. In `renderTextSvg`, escape:
   - `line` (text node content)
   - string-valued attributes from `options` (`fontFamily`, `textColor`)
3. Keep numeric formatting as-is.

This preserves current rendering behavior for normal input while preventing markup/script injection from `node.text` and tainted `options` values.  
Edits are only needed in `src/spd/svg-renderer.ts`, around `renderTextSvg` and helper section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
