### PR TITLE
Potential fix for code scanning alert no. 7: Unsafe HTML constructed from library input

### DIFF
--- a/src/spd/svg-renderer.ts
+++ b/src/spd/svg-renderer.ts
@@ -122,7 +122,7 @@ export function render(
   const baseFillColor = sanitizeSvgColor(mergedOptions.baseBackgroundColor);
   svg += `<rect x="0" y="0" `;
   svg += `width="${svgWidth.toFixed(1)}" height="${svgHeight.toFixed(1)}" `;
-  svg += `fill="${baseFillColor}"/>`;
+  svg += `fill="${escapeXmlAttribute(baseFillColor)}"/>`;
   svg += renderTransformTranslateSvg(
     mergedOptions.margin.left,
     mergedOptions.margin.top,
@@ -131,6 +131,15 @@ export function render(
   svg += `</svg>`;
 
   return svg;
+}
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 function sanitizeSvgColor(color: string | null): string {


### PR DESCRIPTION
Potential fix for [https://github.com/steelpipe75/padtools_ts/security/code-scanning/7](https://github.com/steelpipe75/padtools_ts/security/code-scanning/7)

General fix: ensure any value interpolated into generated SVG/HTML is safely escaped for XML/HTML attribute context, even if it has prior semantic validation. This gives defense-in-depth and satisfies static analysis expectations for unsafe HTML construction from library input.

Best single fix in `src/spd/svg-renderer.ts`:
- Add a small attribute-escaping helper (escape `&`, `<`, `>`, `"`, `'`).
- Apply it when writing `baseFillColor` into the `fill` attribute.
- Keep existing `sanitizeSvgColor` behavior unchanged (no functional regression), just add encoding at output boundary.

This is localized to:
- Around the `render` function where `fill="${baseFillColor}"` is built.
- Add helper function near `sanitizeSvgColor`.

No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
