### PR TITLE
Potential fix for code scanning alert no. 8: Unsafe HTML constructed from library input

### DIFF
--- a/src/spd/svg-renderer.ts
+++ b/src/spd/svg-renderer.ts
@@ -962,10 +962,13 @@ function renderLineSvg(
   y2: number,
   options: RenderOptions,
 ): string {
+  const safeStrokeColor = escapeXmlAttribute(
+    sanitizeSvgColor(options.strokeColor),
+  );
   return `<line
 		x1="${x1.toFixed(1)}" y1="${y1.toFixed(1)}"
 		x2="${x2.toFixed(1)}" y2="${y2.toFixed(1)}"
-		stroke="${options.strokeColor}"
+		stroke="${safeStrokeColor}"
 		stroke-width="${options.strokeWidth}"
 	/>`;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/steelpipe75/padtools_ts/security/code-scanning/8](https://github.com/steelpipe75/padtools_ts/security/code-scanning/8)

General fix: ensure every dynamic value inserted into SVG/XML markup is either (1) constrained to a safe allowlist format (best for colors, enums), or (2) XML-escaped before interpolation. For a library, this should be done internally so callers are safe by default.

Best targeted fix in `src/spd/svg-renderer.ts` (shown region): sanitize/escape `strokeColor` in `renderLineSvg` before inserting into `stroke="..."`. This is the concrete taint sink in the reported path and can be fixed without changing behavior for valid colors.

Change needed:
- In `renderLineSvg` (around lines 964–970), replace direct use of `options.strokeColor` with:
  - `const safeStrokeColor = escapeXmlAttribute(sanitizeSvgColor(options.strokeColor));`
  - then interpolate `safeStrokeColor`.

No new imports or dependencies are required since `sanitizeSvgColor` and `escapeXmlAttribute` are already present in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
