### PR TITLE
Potential fix for code scanning alert no. 8: Unsafe HTML constructed from library input

### DIFF
--- a/src/spd/svg-renderer.ts
+++ b/src/spd/svg-renderer.ts
@@ -216,9 +216,11 @@ function renderBoxFragment(
     contentHeight += options.boxPadding.top + options.boxPadding.bottom;
     textOffsetY += options.boxPadding.top;
     const fillColor = options.backgroundColor ?? "none";
+    const safeStrokeColor = escapeXmlAttribute(options.strokeColor);
+    const safeFillColor = escapeXmlAttribute(fillColor);
     svg += `<rect x="0" y="0" width="${contentWidth.toFixed(1)}" height="${contentHeight.toFixed(1)}" `;
-    svg += `stroke="${options.strokeColor}" stroke-width="${options.strokeWidth}" `;
-    svg += `fill="${fillColor}"/>`;
+    svg += `stroke="${safeStrokeColor}" stroke-width="${options.strokeWidth}" `;
+    svg += `fill="${safeFillColor}"/>`;
   } else if (node.borderType === "WRound") {
     // 丸みを帯びた四角形
     contentHeight += options.boxPadding.top + options.boxPadding.bottom;
@@ -227,10 +229,12 @@ function renderBoxFragment(
     contentWidth += contentHeight;
     textOffsetX = radius;
     const fillColor = options.backgroundColor ?? "none";
+    const safeStrokeColor = escapeXmlAttribute(options.strokeColor);
+    const safeFillColor = escapeXmlAttribute(fillColor);
     svg += `<rect x="0" y="0" width="${contentWidth.toFixed(1)}" height="${contentHeight.toFixed(1)}" `;
     svg += `rx="${radius.toFixed(1)}" ry="${radius.toFixed(1)}" `;
-    svg += `stroke="${options.strokeColor}" stroke-width="${options.strokeWidth}" `;
-    svg += `fill="${fillColor}"/>`;
+    svg += `stroke="${safeStrokeColor}" stroke-width="${options.strokeWidth}" `;
+    svg += `fill="${safeFillColor}"/>`;
   } else {
     // ボーダーなし
     contentWidth += options.boxPadding.left + options.boxPadding.right;


### PR DESCRIPTION
Potential fix for [https://github.com/steelpipe75/padtools_ts/security/code-scanning/8](https://github.com/steelpipe75/padtools_ts/security/code-scanning/8)

The correct fix is to ensure **all caller-controlled string values interpolated into SVG/XML attributes are XML-escaped** before concatenation. In this snippet, the most direct and minimal behavior-preserving fix is to apply the existing `escapeXmlAttribute(...)` helper at the point of use for `options.strokeColor` and `fillColor` in `renderBoxFragment`, which is explicitly on the taint path.

Best single fix in the shown region:
- In `src/spd/svg-renderer.ts`, inside `renderBoxFragment(...)`, where `<rect ... stroke="..." ... fill="..."/>` is built (both `"Box"` and `"WRound"` branches), wrap:
  - `options.strokeColor` with `escapeXmlAttribute(...)`
  - `fillColor` with `escapeXmlAttribute(...)`
- No new dependency is needed.
- No import changes are needed (helper already exists in file).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
