### PR TITLE
Potential fix for code scanning alert no. 8: Unsafe HTML constructed from library input

### DIFF
--- a/src/spd/svg-renderer.ts
+++ b/src/spd/svg-renderer.ts
@@ -98,6 +98,15 @@ const defaultRenderOptions: RenderOptions = {
 /**
  * ASTを受け取り、完全なSVG文字列を返す
  */
+/**
+ * Render AST nodes into an SVG markup string.
+ *
+ * Security note:
+ * - This function returns raw SVG/XML markup assembled from node content and render options.
+ * - If `node` text or `options` values come from untrusted input, do not insert the returned
+ *   string into the DOM as HTML/SVG without sanitization.
+ * - Prefer trusted inputs only, or sanitize before assigning to sinks such as `innerHTML`.
+ */
 export function render(
   node: Node | null,
   options?: Partial<RenderOptions>,


### PR DESCRIPTION
Potential fix for [https://github.com/steelpipe75/padtools_ts/security/code-scanning/8](https://github.com/steelpipe75/padtools_ts/security/code-scanning/8)

Best fix: make the API contract explicit that `render` returns raw SVG markup and should only be used with trusted input or sanitized before DOM insertion. This directly addresses CodeQL’s “library input” concern without changing rendering behavior.

Concretely in `src/spd/svg-renderer.ts`, add a JSDoc security note immediately above the exported `render` function (around line 101) documenting:
- output is raw SVG/HTML string,
- caller must treat `options`/node text as untrusted unless sanitized,
- recommended safe usage (`textContent`, sanitization library, or trusted pipeline only).

This is the safest single change that preserves existing functionality and aligns with CodeQL recommendation for library functions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
